### PR TITLE
eventsCount caching

### DIFF
--- a/database/migrations/20240610104532_cacheSubscriptionsEvents.js
+++ b/database/migrations/20240610104532_cacheSubscriptionsEvents.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.alterTable('subscriptions', (table) => {
+    table.jsonb('eventsCount');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.alterTable('subscriptions', (table) => {
+    table.dropColumn('eventsCount');
+  });
+};

--- a/services/datagov.service.ts
+++ b/services/datagov.service.ts
@@ -168,7 +168,7 @@ export default class DatagovService extends moleculer.Service {
       }
     } while (response?._data?.length);
 
-    this.broker.emit('tiles.events.renew');
+    this.broker.emit('integrations.sync.finished');
     return stats;
   }
 

--- a/services/integrations.fishStockings.service.ts
+++ b/services/integrations.fishStockings.service.ts
@@ -197,7 +197,7 @@ export default class IntegrationsFishStockingsService extends moleculer.Service 
       }
     }
 
-    this.broker.emit('tiles.events.renew');
+    this.broker.emit('integrations.sync.finished');
     return stats;
   }
 }

--- a/services/integrations.lumbering.service.ts
+++ b/services/integrations.lumbering.service.ts
@@ -172,7 +172,7 @@ export default class IntegrationsLumberingService extends moleculer.Service {
       }
     }
 
-    this.broker.emit('tiles.events.renew');
+    this.broker.emit('integrations.sync.finished');
     return stats;
   }
 }

--- a/services/subscriptions.service.ts
+++ b/services/subscriptions.service.ts
@@ -374,11 +374,7 @@ export default class SubscriptionsService extends moleculer.Service {
   }
 
   @Method
-  updateEventsCountCache(
-    ctx: Context,
-    id: Subscription['id'],
-    eventsCount: Subscription['eventsCount'],
-  ) {
+  cacheEventsCount(ctx: Context, id: Subscription['id'], eventsCount: Subscription['eventsCount']) {
     return this.updateEntity(
       ctx,
       {
@@ -415,7 +411,7 @@ export default class SubscriptionsService extends moleculer.Service {
           mapping: true,
         });
 
-        await this.updateEventsCountCache(ctx, id, eventsCounts[id]);
+        await this.cacheEventsCount(ctx, id, eventsCounts[id]);
         break;
     }
   }
@@ -430,7 +426,7 @@ export default class SubscriptionsService extends moleculer.Service {
     const eventsCounts = await this.actions.getEventsCount({ id: allIds, mapping: true });
 
     for (const id in eventsCounts) {
-      await this.updateEventsCountCache(ctx, Number(id), eventsCounts[id]);
+      await this.cacheEventsCount(ctx, Number(id), eventsCounts[id]);
     }
   }
 
@@ -476,7 +472,7 @@ export default class SubscriptionsService extends moleculer.Service {
     const eventsCounts = await this.actions.getEventsCount({ id: allIds, mapping: true });
 
     for (const id in eventsCounts) {
-      await this.updateEventsCountCache(null, Number(id), eventsCounts[id]);
+      await this.cacheEventsCount(null, Number(id), eventsCounts[id]);
     }
   }
 }

--- a/services/subscriptions.service.ts
+++ b/services/subscriptions.service.ts
@@ -54,7 +54,6 @@ export type Subscription<
   mixins: [
     DbConnection({
       collection: 'subscriptions',
-      entityChangedOldEntity: true,
     }),
     PostgisMixin({ srid: LKS_SRID }),
   ],
@@ -141,13 +140,9 @@ export type Subscription<
       },
 
       eventsCount: {
-        type: 'object',
+        type: 'any',
         readonly: true,
-        properties: {
-          allTime: 'number',
-          new: 'number',
-        },
-        get: ({ value }: FieldHookCallback) => value || { allTime: 0, new: 0 },
+        set: () => null,
       },
 
       frequency: {
@@ -396,11 +391,11 @@ export default class SubscriptionsService extends moleculer.Service {
   async 'subscriptions.*'(ctx: Context<EntityChangedParams<Subscription>>) {
     const type = ctx.params.type;
     const subscription = ctx.params.data;
-    const subscriptionOld = ctx.params.oldData;
     const id = subscription.id;
 
     if (!id) return;
-    if (subscription.geom === subscriptionOld?.geom) return;
+
+    if (subscription.eventsCount) return;
 
     switch (type) {
       case 'create':

--- a/services/tiles.events.service.ts
+++ b/services/tiles.events.service.ts
@@ -379,7 +379,7 @@ export default class TilesEventsService extends moleculer.Service {
   }
 
   @Event()
-  async 'tiles.events.renew'() {
+  async 'integrations.sync.finished'() {
     this.superclustersPromises = {};
     await this.renewSuperclusterIndex();
   }


### PR DESCRIPTION
Closes #92 

Cache atnaujinamas trim atvejais:
- `integrations.sync.finished` - po `cron` visi subscriptions atnaujinami
- `subscriptions.update|create` - kai subscription sukuriamas/redaguojamas - tik jam atnaujinama
- `started` - serviso startavimo metu - visi kurie neturi cache reiksmes (pirma karta aktualu, ir jei DB kazkas insertintu, nors taip ir nebus)