### PR TITLE
Default SERVICEDIR environment variable 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ ARG ENVIRONMENT
 ENV ENVIRONMENT=${ENVIRONMENT}
 
 # Set default environment variables
+ENV SERVICEDIR=dist/services
 ENV NODE_ENV=production
 ENV TZ=Etc/GMT
 


### PR DESCRIPTION
Ensure `yarn start` works by setting the `SERVICEDIR` environment variable in the Dockerfile. This prevents potential debugging issues when the variable is not set. While an internal Moleculer solution could be considered, the Dockerfile approach is straightforward and effective. Ideally, I would like to replicate the same approach across all API projects that use Moleculer. 